### PR TITLE
Fix dependencies for npm 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"author": "Tobias Koppers @sokra",
 	"description": "coffee redux loader module for webpack",
 	"dependencies": {
-		"coffee-script-redux": "2.0.x",
+		"coffee-script-redux": ">=2.0.0-beta0 <2.1.0",
 		"loader-utils": "0.2.x"
 	},
 	"devDependencies": {


### PR DESCRIPTION
npm 2+ can't install `coffee-redux-loader` because prerelease versions don't show up in ranges: https://github.com/npm/npm/releases/tag/v2.0.0
